### PR TITLE
remove metric from topchef add getter setter in chef base

### DIFF
--- a/src/contracts/Chef.sol
+++ b/src/contracts/Chef.sol
@@ -36,7 +36,7 @@ abstract contract Chef is Ownable {
         _metricPerBlock = metricAmount * 10**18;
     }
 
-    function setLastRewardBlock(uint256 blockNumber) public virtual {
+    function setLastRewardBlock(uint256 blockNumber) internal virtual {
         _lastRewardBlock = blockNumber;
     }
 
@@ -73,5 +73,12 @@ abstract contract Chef is Ownable {
 
     event Harvest(address harvester, uint256 agIndex, uint256 amount);
     event Withdraw(address withdrawer, uint256 agIndex, uint256 amount);
+
+    receive() external payable virtual {}
+
+    function withdrawMoney() public onlyOwner() {
+        address payable to = payable(msg.sender);
+        to.transfer(address(this).balance);
+    }
 
 }

--- a/src/contracts/Chef.sol
+++ b/src/contracts/Chef.sol
@@ -76,9 +76,6 @@ abstract contract Chef is Ownable {
 
     receive() external payable virtual {}
 
-    function withdrawMoney() public onlyOwner() {
-        address payable to = payable(msg.sender);
-        to.transfer(address(this).balance);
-    }
+    function withdrawMoney() public onlyOwner() {}
 
 }

--- a/src/contracts/Chef.sol
+++ b/src/contracts/Chef.sol
@@ -58,7 +58,7 @@ abstract contract Chef is Ownable {
         return _rewardsActive;
     }
 
-    function getMetricToken() public view virtual returns (MetricToken) {
+    function getMetricToken() internal view virtual returns (MetricToken) {
         return _metric;
     }
 

--- a/src/contracts/Chef.sol
+++ b/src/contracts/Chef.sol
@@ -40,6 +40,10 @@ abstract contract Chef is Ownable {
         _lastRewardBlock = blockNumber;
     }
 
+    function setMetricToken(address metricTokenAddress) public virtual onlyOwner() {
+        _metric = MetricToken(metricTokenAddress);
+    }
+
     //------------------------------------------------------Getters
 
     function getMetricPerBlock() public view virtual returns(uint256) {
@@ -52,6 +56,10 @@ abstract contract Chef is Ownable {
 
     function areRewardsActive() public view virtual returns (bool) {
         return _rewardsActive;
+    }
+
+    function getMetricToken() public view virtual returns (MetricToken) {
+        return _metric;
     }
 
     //------------------------------------------------------Support Functions

--- a/src/contracts/Chef.sol
+++ b/src/contracts/Chef.sol
@@ -74,8 +74,4 @@ abstract contract Chef is Ownable {
     event Harvest(address harvester, uint256 agIndex, uint256 amount);
     event Withdraw(address withdrawer, uint256 agIndex, uint256 amount);
 
-    receive() external payable virtual {}
-
-    function withdrawMoney() public onlyOwner() {}
-
 }

--- a/src/contracts/TopChef.sol
+++ b/src/contracts/TopChef.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "./Chef.sol";
-import "./MetricToken.sol";
 
 contract TopChef is Chef {
     using SafeMath for uint256;
@@ -11,10 +10,8 @@ contract TopChef is Chef {
     uint256 private _totalAllocPoint;
     uint256 private _lifetimeShareValue;
 
-    MetricToken private _metric;
-
     constructor(address metricTokenAddress) {
-        _metric = MetricToken(metricTokenAddress);
+        setMetricToken(metricTokenAddress);
         setMetricPerBlock(4);
     }
 
@@ -131,7 +128,8 @@ contract TopChef is Chef {
         group.rewardDebt = claimable;
         if (claimable != 0) {
             if (group.autodistribute) {
-                _metric.transfer(group.groupAddress, claimable);
+                MetricToken metric = getMetricToken();
+                metric.transfer(group.groupAddress, claimable);
                 group.claimable = 0;
             } else {
                 group.claimable = group.claimable.add(claimable);
@@ -146,7 +144,8 @@ contract TopChef is Chef {
         require(group.claimable != 0, "No claimable rewards to withdraw");
         // TODO do we want a backup in case a group looses access to their wallet
         require(group.groupAddress == _msgSender(), "Sender does not represent group");
-        _metric.transfer(group.groupAddress, group.claimable);
+        MetricToken metric = getMetricToken();
+        metric.transfer(group.groupAddress, group.claimable);
         group.claimable = 0;
 
         emit Withdraw(msg.sender, agIndex, group.claimable);


### PR DESCRIPTION
realized I left out metric token out of base chef - these changes call a setter within constructor only by owner and a getter as well to send transfers 