### PR TITLE
Mdao

### DIFF
--- a/src/contracts/Protocol/ActionCostController.sol
+++ b/src/contracts/Protocol/ActionCostController.sol
@@ -31,7 +31,7 @@ contract ActionCostController is Ownable, IActionCostController {
     */
     function payForCreateQuestion(address _user) external onlyApi {
         // TODO where do we want to store locked metric?
-        lockedPerUser[msg.sender] += createCost;
+        lockedPerUser[_user] += createCost;
         // Why safeERC20?
         SafeERC20.safeTransferFrom(metric, _user, address(this), createCost);
     }
@@ -50,6 +50,11 @@ contract ActionCostController is Ownable, IActionCostController {
      */
     function setQuestionApi(address _questionApi) public onlyOwner {
         questionApi = _questionApi;
+    }
+
+    // ------------------------------- Getter
+    function getLockedPerUser(address _user) public view returns (uint256) {
+        return lockedPerUser[_user];
     }
 
     // ------------------------------- Modifier

--- a/src/contracts/Protocol/BountyQuestion.sol
+++ b/src/contracts/Protocol/BountyQuestion.sol
@@ -29,7 +29,7 @@ contract BountyQuestion is ERC721, ERC721Enumerable, ERC721URIStorage, ERC721Bur
     constructor() ERC721("MetricsDAO Question", "MDQ") {}
 
     // working standard metadata format:  Title, Description, Program
-    function safeMint(address to, string memory uri) public onlyOwner returns (uint256) {
+    function safeMint(address to, string calldata uri) public returns (uint256) {
         uint256 tokenId = _tokenIdCounter.current();
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);

--- a/src/contracts/Protocol/QuestionAPI.sol
+++ b/src/contracts/Protocol/QuestionAPI.sol
@@ -69,7 +69,15 @@ contract QuestionAPI is Ownable {
         if (_questionStateController.getState(questionId) == uint256(IQuestionStateController.STATE.DRAFT)) {
             _questionStateController.readyForVotes(questionId);
         }
-        _questionStateController.voteFor(questionId, amount);
+        _questionStateController.voteFor(msg.sender, questionId, amount);
+    }
+
+    /**
+     * @notice Unvotes a question
+     * @param questionId The questionId of the question to upvote
+     */
+    function unvoteQuestion(uint256 questionId) public {
+        _questionStateController.unvoteFor(msg.sender, questionId);
     }
 
     // TODO lock metric

--- a/src/contracts/Protocol/QuestionAPI.sol
+++ b/src/contracts/Protocol/QuestionAPI.sol
@@ -81,6 +81,10 @@ contract QuestionAPI is Ownable {
         _claimController.answer(questionId, answerURL);
     }
 
+    /**
+     * @notice Changes the cost of creating a question
+     * @param cost The new cost of creating a question
+     */
     function setCreateCost(uint256 cost) public onlyOwner {
         _costController.setCreateCost(cost);
     }

--- a/src/contracts/Protocol/QuestionAPI.sol
+++ b/src/contracts/Protocol/QuestionAPI.sol
@@ -63,8 +63,12 @@ contract QuestionAPI is Ownable {
      * @notice Upvotes a question
      * @param questionId The questionId of the question to upvote
      * @param amount Metric amount to put behind the vote
+     * We can manipulate this very easily -- think of a way to make it secure
      */
     function upvoteQuestion(uint256 questionId, uint256 amount) public {
+        if (_questionStateController.getState(questionId) == uint256(IQuestionStateController.STATE.DRAFT)) {
+            _questionStateController.readyForVotes(questionId);
+        }
         _questionStateController.voteFor(questionId, amount);
     }
 

--- a/src/contracts/Protocol/QuestionAPI.sol
+++ b/src/contracts/Protocol/QuestionAPI.sol
@@ -36,21 +36,37 @@ contract QuestionAPI is Ownable {
     // TODO add "unvote"
 
     // TODO lock metric
-    function createQuestion(string memory uri, uint256 claimLimit) public {
-        _costController.payForCreateQuestion();
+    // uint8?
 
-        uint256 newTokenId = _question.safeMint(_msgSender(), uri);
+    /**
+     * @notice Creates a question
+     * @param uri The IPFS hash of the question
+     * @param claimLimit The limit for the amount of people that can claim the question
+     * @return The question id
+     */
+    function createQuestion(string calldata uri, uint256 claimLimit) public returns (uint256) {
+        // Pay to create a question
+        _costController.payForCreateQuestion(msg.sender);
 
-        _questionStateController.initializeQuestion(newTokenId);
-        _claimController.initializeQuestion(newTokenId, claimLimit);
+        // Mint a new question
+        uint256 questionId = _question.safeMint(_msgSender(), uri);
+
+        // Initialize the question
+        _questionStateController.initializeQuestion(questionId);
+        _claimController.initializeQuestion(questionId, claimLimit);
+
+        return questionId;
     }
 
     // TODO lock metric
+    /**
+     * @notice Upvotes a question
+     * @param questionId The questionId of the question to upvote
+     * @param amount Metric amount to put behind the vote
+     */
     function upvoteQuestion(uint256 questionId, uint256 amount) public {
         _questionStateController.voteFor(questionId, amount);
     }
-
-    error ClaimsNotOpen();
 
     // TODO lock metric
     function claimQuestion(uint256 questionId) public {
@@ -64,6 +80,13 @@ contract QuestionAPI is Ownable {
     function answerQuestion(uint256 questionId, string calldata answerURL) public {
         _claimController.answer(questionId, answerURL);
     }
+
+    function setCreateCost(uint256 cost) public onlyOwner {
+        _costController.setCreateCost(cost);
+    }
+
+    //------------------------------------------------------ Errors
+    error ClaimsNotOpen();
 
     //------------------------------------------------------ Proxy
 

--- a/src/contracts/Protocol/QuestionStateController.sol
+++ b/src/contracts/Protocol/QuestionStateController.sol
@@ -5,13 +5,18 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/IQuestionStateController.sol";
 
 contract QuestionStateController is IQuestionStateController, Ownable {
+    address public questionApi;
     mapping(uint256 => QuestionVote) public votes;
     mapping(uint256 => STATE) public state;
 
     // TODO ? map a user's address to their votes
     // TODO do we want user to lose their metric if a question is closed? they voted on somethjing bad
 
-    function initializeQuestion(uint256 questionId) public onlyOwner {
+    /**
+     * @notice Initializes a question to draft.
+     * @param questionId The id of the question
+     */
+    function initializeQuestion(uint256 questionId) public onlyApi {
         state[questionId] = STATE.DRAFT;
     }
 
@@ -39,6 +44,17 @@ contract QuestionStateController is IQuestionStateController, Ownable {
 
     function getVotes(uint256 questionId) public view returns (Vote[] memory _votes) {
         return votes[questionId].votes;
+    }
+
+    function setQuestionApi(address _questionApi) public onlyOwner {
+        questionApi = _questionApi;
+    }
+
+    // ------------------------------- Modifier
+    error NotTheApi();
+    modifier onlyApi() {
+        if (msg.sender != questionApi) revert NotTheApi();
+        _;
     }
 
     //------------------------------------------------------ Structs

--- a/src/contracts/Protocol/QuestionStateController.sol
+++ b/src/contracts/Protocol/QuestionStateController.sol
@@ -20,7 +20,7 @@ contract QuestionStateController is IQuestionStateController, Ownable {
         state[questionId] = STATE.DRAFT;
     }
 
-    function readyForVotes(uint256 questionId) public onlyOwner onlyState(STATE.DRAFT, questionId) {
+    function readyForVotes(uint256 questionId) public onlyApi onlyState(STATE.DRAFT, questionId) {
         state[questionId] = STATE.VOTING;
     }
 
@@ -28,10 +28,11 @@ contract QuestionStateController is IQuestionStateController, Ownable {
         state[questionId] = STATE.PUBLISHED;
     }
 
-    function voteFor(uint256 questionId, uint256 amount) public onlyOwner onlyState(STATE.VOTING, questionId) {
+    function voteFor(uint256 questionId, uint256 amount) public onlyApi onlyState(STATE.VOTING, questionId) {
         Vote memory _vote = Vote({voter: _msgSender(), amount: amount, weightedVote: amount});
         votes[questionId].votes.push(_vote);
-        votes[questionId].totalVoteCount = votes[questionId].totalVoteCount + amount;
+        votes[questionId].totalVoteCount += amount;
+        // Lock tokens for voting
     }
 
     // TODO batch voting and batch operations and look into arrays as parameters security risk
@@ -44,6 +45,10 @@ contract QuestionStateController is IQuestionStateController, Ownable {
 
     function getVotes(uint256 questionId) public view returns (Vote[] memory _votes) {
         return votes[questionId].votes;
+    }
+
+    function getTotalVotes(uint256 questionId) public view returns (uint256) {
+        return votes[questionId].totalVoteCount;
     }
 
     function setQuestionApi(address _questionApi) public onlyOwner {

--- a/src/contracts/Protocol/interfaces/IActionCostController.sol
+++ b/src/contracts/Protocol/interfaces/IActionCostController.sol
@@ -2,5 +2,7 @@
 pragma solidity 0.8.13;
 
 interface IActionCostController {
-    function payForCreateQuestion() external;
+    function payForCreateQuestion(address _user) external;
+
+    function setCreateCost(uint256 _cost) external;
 }

--- a/src/contracts/Protocol/interfaces/IActionCostController.sol
+++ b/src/contracts/Protocol/interfaces/IActionCostController.sol
@@ -5,4 +5,6 @@ interface IActionCostController {
     function payForCreateQuestion(address _user) external;
 
     function setCreateCost(uint256 _cost) external;
+
+    function getLockedPerUser(address _user) external view returns (uint256);
 }

--- a/src/contracts/Protocol/interfaces/IQuestionStateController.sol
+++ b/src/contracts/Protocol/interfaces/IQuestionStateController.sol
@@ -6,6 +6,8 @@ interface IQuestionStateController {
 
     function voteFor(uint256 questionId, uint256 amount) external;
 
+    function readyForVotes(uint256 questionId) external;
+
     // TODO currentState can probably be like a uint8, it depends on how many states we have
     function getState(uint256 quesitonId) external view returns (uint256 currentState);
 

--- a/src/contracts/Protocol/interfaces/IQuestionStateController.sol
+++ b/src/contracts/Protocol/interfaces/IQuestionStateController.sol
@@ -4,7 +4,13 @@ pragma solidity 0.8.13;
 interface IQuestionStateController {
     function initializeQuestion(uint256 questionId) external;
 
-    function voteFor(uint256 questionId, uint256 amount) external;
+    function voteFor(
+        address _user,
+        uint256 questionId,
+        uint256 amount
+    ) external;
+
+    function unvoteFor(address _user, uint256 questionId) external;
 
     function readyForVotes(uint256 questionId) external;
 

--- a/src/test/QuestionAPI.t.sol
+++ b/src/test/QuestionAPI.t.sol
@@ -108,5 +108,27 @@ contract QuestionAPITest is Test {
         vm.stopPrank();
     }
 
+    function test_CreateQuestionAndVoteForQuestion() public {
+        console.log("Should correctly create a question and vote for it");
+
+        vm.startPrank(other);
+        // Create a question and see that it is created and balance is updated.
+        assertEq(_metricToken.balanceOf(other), 100e18);
+        _metricToken.approve(address(_costController), 100e18);
+        uint256 questionId = _questionAPI.createQuestion("ipfs://XYZ", 25);
+        assertEq(_metricToken.balanceOf(other), 99e18);
+
+        // Assert that the question is now a DRAFT and has the correct data (claim limit).
+        assertEq(_questionStateController.getState(questionId), uint256(IQuestionStateController.STATE.DRAFT));
+        assertEq(_claimController.getClaimLimit(questionId), 25);
+
+        // Vote for the question
+        _questionAPI.upvoteQuestion(questionId, 5e18);
+        assertEq(_metricToken.balanceOf(other), 99e18);
+        assertEq(_questionStateController.getState(questionId), uint256(IQuestionStateController.STATE.VOTING));
+        assertEq(_questionStateController.getTotalVotes(questionId), 5e18);
+        vm.stopPrank();
+    }
+
     // --------------------- Testing for access controlls
 }

--- a/src/test/QuestionAPI.t.sol
+++ b/src/test/QuestionAPI.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "forge-std/Vm.sol";
+import "@contracts/MetricToken.sol";
+import "@contracts/Protocol/QuestionAPI.sol";
+import "@contracts/Protocol/ClaimController.sol";
+import "@contracts/Protocol/QuestionStateController.sol";
+import "@contracts/Protocol/BountyQuestion.sol";
+import "@contracts/Protocol/ActionCostController.sol";
+
+contract QuestionAPITest is Test {
+    // Accounts
+    address owner = address(0x0a);
+    address other = address(0x0b);
+
+    MetricToken _metricToken;
+    QuestionAPI _questionAPI;
+    BountyQuestion _bountyQuestion;
+    ClaimController _claimController;
+    ActionCostController _costController;
+    QuestionStateController _questionStateController;
+
+    function setUp() public {
+        // Labeling
+        vm.label(owner, "Owner");
+        vm.label(other, "User");
+
+        vm.startPrank(owner);
+        _metricToken = new MetricToken();
+        _bountyQuestion = new BountyQuestion();
+        _claimController = new ClaimController();
+        _questionStateController = new QuestionStateController();
+        _costController = new ActionCostController(address(_metricToken));
+        _questionAPI = new QuestionAPI(
+            address(_metricToken),
+            address(_bountyQuestion),
+            address(_questionStateController),
+            address(_claimController),
+            address(_costController)
+        );
+
+        _claimController.setQuestionApi(address(_questionAPI));
+        _costController.setQuestionApi(address(_questionAPI));
+        _questionStateController.setQuestionApi(address(_questionAPI));
+
+        _metricToken.transfer(other, 100e18);
+        vm.stopPrank();
+    }
+
+    function test_InitialMint() public {
+        console.log("Should correctly distribute initial mint");
+        assertEq(_metricToken.balanceOf(owner), 1000000000e18 - 100e18);
+    }
+
+    function test_CreateQuestion() public {
+        console.log("Should correctly create a question");
+
+        vm.startPrank(other);
+        // Create a question and see that it is created and balance is updated.
+        assertEq(_metricToken.balanceOf(other), 100e18);
+        _metricToken.approve(address(_costController), 100e18);
+        uint256 questionId = _questionAPI.createQuestion("ipfs://XYZ", 25);
+        assertEq(_metricToken.balanceOf(other), 99e18);
+
+        // Assert that the question is now a DRAFT and has the correct data (claim limit).
+        assertEq(_questionStateController.getState(questionId), uint256(IQuestionStateController.STATE.DRAFT));
+        assertEq(_claimController.getClaimLimit(questionId), 25);
+        vm.stopPrank();
+    }
+}

--- a/src/test/QuestionAPI.t.sol
+++ b/src/test/QuestionAPI.t.sol
@@ -108,7 +108,7 @@ contract QuestionAPITest is Test {
         vm.stopPrank();
     }
 
-    function test_CreateQuestionAndVoteForQuestion() public {
+    function test_CreateQuestionAndVoteForQuestionThenUnvoteForQuestion() public {
         console.log("Should correctly create a question and vote for it");
 
         vm.startPrank(other);
@@ -127,6 +127,15 @@ contract QuestionAPITest is Test {
         assertEq(_metricToken.balanceOf(other), 99e18);
         assertEq(_questionStateController.getState(questionId), uint256(IQuestionStateController.STATE.VOTING));
         assertEq(_questionStateController.getTotalVotes(questionId), 5e18);
+
+        // Question is set for the right address and values
+        _questionStateController.getVotes(questionId);
+
+        // Unvote for the question
+        _questionAPI.unvoteQuestion(questionId);
+
+        // Check that accounting was done properly.
+        _questionStateController.getVotes(questionId);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
- Added some comments
- Added tests for question creation, upvoting, unvoting and changing costs.
- Fixed logic where we use msg.sender (we interact between contracts so the message sender is always changed to the contract making the call instead of the user). 
- Added the possibility to set the questionApi in the contracts. We currently set the questionApi contract as owner of the other contracts. But we do not have the opportunity to set ownership from the questionApi to another address, meaning we would need to redeploy all other contracts when we upgrade or fix a bug in questionApi. This of course is something we should discus and I am not sure if it is the right way of doing things. I do prefer the naming of onlyApi modifier over onlyOwner.
- Added option to change costs of creating a question
- Added getter to check the amount of metric locked by a user
- Fixed accounting issues of creating a question (previously we would overwrite the cost of a user on each new question, this would limit a user to either limit a user to a single question or lose his/her metric (accounting error)).

Some of these might be nice to discuss, but figured it would be a good idea to push this before continuing on the rest.

Let me know!